### PR TITLE
2024-10-02-leap-CUDA: make driver installation instructions more robust

### DIFF
--- a/_posts/2024-10-02-leap-CUDA.md
+++ b/_posts/2024-10-02-leap-CUDA.md
@@ -61,19 +61,15 @@ consist of the low level driver stack as well as the CUDA libraries.
 In a containerized system, the libraries would reside inside the application
 container.
 
-To install the runtime stack for CUDA 12.5, we would simply run:
+To install the runtime stack for CUDA 12.9, we would simply run:
 ```
 # zypper ar https://developer.download.nvidia.com/compute/cuda/repos/opensuse15/x86_64/cuda-opensuse15.repo
 # zypper --gpg-auto-import-keys refresh
-# zypper -n in -y --auto-agree-with-licenses --no-recommends \
-     nv-prefer-signed-open-driver cuda-runtime-12-5
+# zypper -n in -y nv-prefer-signed-open-driver
+# version=$(rpm -qa --queryformat '%{VERSION}\n' nv-prefer-signed-open-driver | cut -d "_" -f1 | sort -u | tail -n 1)
+# zypper -n in -y --auto-agree-with-licenses \
+    nvidia-compute-utils-G06 = ${version} cuda-libraries-12-9
 ```
-* If we don't need 32-bit compatibility packages, we may should add the
-  option `--no-recommends`.
-* Note that we are deliberately choosing CUDA 12.5 and driver stack version
-  555.42.06 over the the latest one (12.6) as the later and its matching kernel
-  driver version have dependency issues. To install a different version we
-  would replace `12-5' by this version.
 
 The command above will install the SUSE-built and signed driver. Further
 changes to the module configuration as described in the [previous blog](https://e4t.github.io/nvidia/hmm/cuda/2023/10/06/leap_nvidia_hmm.html)
@@ -137,14 +133,12 @@ inside a container.
 ```
 # zypper ar https://developer.download.nvidia.com/compute/cuda/repos/opensuse15/x86_64/cuda-opensuse15.repo
 # zypper --gpg-auto-import-keys refresh
-# zypper -n in -y nvidia-compute-utils-G06 [ = <version> ] \
-   nv-prefer-signed-open-driver \
-   nvidia-container-toolkit
+# zypper -n in -y nv-prefer-signed-open-driver
+# version=$(rpm -qa --queryformat '%{VERSION}\n' nv-prefer-signed-open-driver | cut -d "_" -f1 | sort -u | tail -n 1)
+# zypper -n in -y --auto-agree-with-licenses \
+    nvidia-compute-utils-G06 = ${version} \
+    nvidia-container-toolkit
 ```
-`<version>` specify the driver stack version. If we omit this, we
-will get the latest version available. Again, if we don't need 32-bit
-compatibility packages, we should add `--no-recommends`.
-
 Now, we can configure podman for the devices found in our system:
 ```
 # nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
@@ -176,12 +170,11 @@ the driver stack needs to be installed on each container host.
 ```
 # zypper ar https://developer.download.nvidia.com/compute/cuda/repos/opensuse15/x86_64/cuda-opensuse15.repo
 # zypper --gpg-auto-import-keys refresh
-# zypper -n in -y [ --no-recommends ] nvidia-compute-utils-G06 [ = <version> ] \
-   nv-prefer-signed-open-driver
+# zypper -n in -y nv-prefer-signed-open-driver
+# version=$(rpm -qa --queryformat '%{VERSION}\n' nv-prefer-signed-open-driver | cut -d "_" -f1 | sort -u | tail -n 1)
+# zypper -n in -y --auto-agree-with-licenses \
+    nvidia-compute-utils-G06 = ${version}
 ```
-Here, we may specify a driver version explicitly: if we plan to use
-one other than the latest. Also, we may exclude 32-bit libraries by specifying
-`--no-recommends`.
 We need to perform above steps on each node (ie, server, agents) which
 have an NVIDIA GPU installed.
 How to continue depends whether we perfer to use the NVIDIA GPU Operator


### PR DESCRIPTION
Open kernel driver KMP must be in sync with userspace drivers. Therefore it is recommended to install the KMP first, then figure out which version has been installed, and then install the corresponding user space drivers.

On Bare Metal it was missing the installation of the userspace drivers completely.

CUDA is meanwhile at version 12.9 with 575 drivers.

-32bit packages are no longer recommended. Therefore --no-recommends is no longer needed.

Unfortunately we always need to specify the version when installing userspace drivers (drivers need to be in sync; see above).